### PR TITLE
chore: bump version to 7.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddc-primitives"
-version = "7.3.2"
+version = "7.3.3"
 authors = ["Cerebellum-Network"]
 edition = "2021"
 homepage = "https://cere.network/"


### PR DESCRIPTION
Patch bump after the polkadot-sdk umbrella migration (PR #36).

7.3.2 → **7.3.3**